### PR TITLE
Fix arm64 builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.8] - 2023-12-28
+
+### Changed
+* Upgraded pyinstaller to v6.3.0
+
 ## [0.8.7] - 2023-12-27
 
 ### Changed
@@ -151,7 +156,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Implementation of PoC (simple `b2_application_key` data source)
 
-[Unreleased]: https://github.com/Backblaze/terraform-provider-b2/compare/v0.8.6...HEAD
+[Unreleased]: https://github.com/Backblaze/terraform-provider-b2/compare/v0.8.8...HEAD
+[0.8.8]: https://github.com/Backblaze/terraform-provider-b2/compare/v0.8.7...v0.8.8
 [0.8.7]: https://github.com/Backblaze/terraform-provider-b2/compare/v0.8.6...v0.8.7
 [0.8.6]: https://github.com/Backblaze/terraform-provider-b2/compare/v0.8.5...v0.8.6
 [0.8.5]: https://github.com/Backblaze/terraform-provider-b2/compare/v0.8.4...v0.8.5

--- a/python-bindings/GNUmakefile
+++ b/python-bindings/GNUmakefile
@@ -25,7 +25,7 @@ clean:
 	@rm -rf build dist ${EGG_INFO}
 
 build:
-	@pyinstaller --onefile ${SPEC}
+	@pyinstaller ${SPEC}
 ifeq ($(UNAME_), Linux)
 	@mv -f dist/py-terraform-provider-b2 dist/py-terraform-provider-b2-linked
 	@staticx --strip --loglevel INFO dist/py-terraform-provider-b2-linked dist/py-terraform-provider-b2

--- a/python-bindings/requirements-dev.txt
+++ b/python-bindings/requirements-dev.txt
@@ -2,6 +2,6 @@
 
 black~=22.3.0
 flake8~=3.9.0
-pyinstaller~=4.10
+pyinstaller~=6.3.0
 patchelf-wrapper~=1.2 ; sys_platform == 'linux'
 staticx~=0.13.8 ; sys_platform == 'linux'


### PR DESCRIPTION
In the upstream, arm64 build packages Python bindings that were compiled for amd64 architecture. This PR fixes this.